### PR TITLE
removed return types - thanks a lot Shopware

### DIFF
--- a/Commands/ExportCategories.php
+++ b/Commands/ExportCategories.php
@@ -37,7 +37,7 @@ class ExportCategories extends ShopwareCommand
     /**
      * {@inheritdoc}
      */
-    protected function configure(): void
+    protected function configure()
     {
         $this
             ->setName('Afterbuy:Export:Categories')

--- a/Commands/UpdateOrders.php
+++ b/Commands/UpdateOrders.php
@@ -66,7 +66,7 @@ class UpdateOrders extends ShopwareCommand
     /**
      * {@inheritdoc}
      */
-    protected function configure(): void
+    protected function configure()
     {
         $this
             ->setName('Afterbuy:Update:Orders')

--- a/Commands/UpdateProducts.php
+++ b/Commands/UpdateProducts.php
@@ -64,7 +64,7 @@ class UpdateProducts extends ShopwareCommand
     /**
      * {@inheritdoc}
      */
-    protected function configure(): void
+    protected function configure()
     {
         $this
             ->setName('Afterbuy:Update:Products')

--- a/Models/Status.php
+++ b/Models/Status.php
@@ -53,7 +53,7 @@ class Status extends ModelEntity {
     /**
      * @param mixed $id
      */
-    public function setId($id): void
+    public function setId($id)
     {
         $this->id = $id;
     }
@@ -61,7 +61,7 @@ class Status extends ModelEntity {
     /**
      * @return \DateTime
      */
-    public function getLastOrderImport(): \DateTime
+    public function getLastOrderImport()
     {
         return $this->lastOrderImport;
     }
@@ -69,7 +69,7 @@ class Status extends ModelEntity {
     /**
      * @param \DateTime $lastOrderImport
      */
-    public function setLastOrderImport(\DateTime $lastOrderImport): void
+    public function setLastOrderImport(\DateTime $lastOrderImport)
     {
         $this->lastOrderImport = $lastOrderImport;
     }
@@ -77,7 +77,7 @@ class Status extends ModelEntity {
     /**
      * @return \DateTime
      */
-    public function getLastProductImport(): \DateTime
+    public function getLastProductImport()
     {
         return $this->lastProductImport;
     }
@@ -85,7 +85,7 @@ class Status extends ModelEntity {
     /**
      * @param \DateTime $lastProductImport
      */
-    public function setLastProductImport(\DateTime $lastProductImport): void
+    public function setLastProductImport(\DateTime $lastProductImport)
     {
         $this->lastProductImport = $lastProductImport;
     }
@@ -93,7 +93,7 @@ class Status extends ModelEntity {
     /**
      * @return \DateTime
      */
-    public function getLastStatusExport(): \DateTime
+    public function getLastStatusExport()
     {
         return $this->lastStatusExport;
     }
@@ -101,7 +101,7 @@ class Status extends ModelEntity {
     /**
      * @param \DateTime $lastStatusExport
      */
-    public function setLastStatusExport(\DateTime $lastStatusExport): void
+    public function setLastStatusExport(\DateTime $lastStatusExport)
     {
         $this->lastStatusExport = $lastStatusExport;
     }
@@ -109,7 +109,7 @@ class Status extends ModelEntity {
     /**
      * @return \DateTime
      */
-    public function getLastProductExport(): \DateTime
+    public function getLastProductExport()
     {
         return $this->lastProductExport;
     }
@@ -117,7 +117,7 @@ class Status extends ModelEntity {
     /**
      * @param \DateTime $lastProductExport
      */
-    public function setLastProductExport(\DateTime $lastProductExport): void
+    public function setLastProductExport(\DateTime $lastProductExport)
     {
         $this->lastProductExport = $lastProductExport;
     }

--- a/Services/Helper/AbstractHelper.php
+++ b/Services/Helper/AbstractHelper.php
@@ -249,7 +249,7 @@ class AbstractHelper {
      *
      * @return Media
      */
-    public function createMediaImage($url, $albumName): ?Media
+    public function createMediaImage($url, $albumName)
     {
         if(!$url) {
             return null;
@@ -319,7 +319,7 @@ class AbstractHelper {
      *
      * @return string
      */
-    public function filterNotAllowedCharactersFromURL(string $url): string
+    public function filterNotAllowedCharactersFromURL(string $url)
     {
         $badCharacters = '()+.';
 

--- a/Services/Helper/AfterbuyProductsHelper.php
+++ b/Services/Helper/AfterbuyProductsHelper.php
@@ -327,7 +327,7 @@ class AfterbuyProductsHelper extends ShopwareArticleHelper {
      * @param array        $product
      * @param ValueArticle $valueArticle
      */
-    public function addProductPictures(array $product, ValueArticle $valueArticle): void
+    public function addProductPictures(array $product, ValueArticle $valueArticle)
     {
         $mainPicture = new ProductPicture();
         $mainPicture->setNr(0);

--- a/Services/Helper/ShopwareArticleHelper.php
+++ b/Services/Helper/ShopwareArticleHelper.php
@@ -337,7 +337,7 @@ ON duplicate key update afterbuy_id = $externalId;";
     /**
      * @return array
      */
-    public function getDetailIDsByExternalIdentifier(): array
+    public function getDetailIDsByExternalIdentifier()
     {
         return $this->entityManager->createQueryBuilder()
             ->select(['detail.id', 'detail.articleId', 'detail.number'])

--- a/Services/Helper/ShopwareCategoryHelper.php
+++ b/Services/Helper/ShopwareCategoryHelper.php
@@ -16,7 +16,7 @@ class ShopwareCategoryHelper extends AbstractHelper {
     /**
      * @return ShopwareCategory[]
      */
-    public function getAllCategories(): array {
+    public function getAllCategories() {
         return $this->entityManager->getRepository($this->entity)->findAll();
     }
 
@@ -35,7 +35,7 @@ class ShopwareCategoryHelper extends AbstractHelper {
      *
      * @return ShopwareCategory
      */
-    public function findParentCategory(ValueCategory $category, string $identifier): ShopwareCategory
+    public function findParentCategory(ValueCategory $category, string $identifier)
     {
         $parent = null;
 
@@ -60,7 +60,7 @@ class ShopwareCategoryHelper extends AbstractHelper {
      *
      * @return array
      */
-    public function buildAfterbuyCatalogStructure(array $valueCategories): array
+    public function buildAfterbuyCatalogStructure(array $valueCategories)
     {
         $valueCategories = $this->sortValueCategoriesByParentID($valueCategories);
 
@@ -117,7 +117,7 @@ class ShopwareCategoryHelper extends AbstractHelper {
      *
      * @return ValueCategory[]
      */
-    public function sortValueCategoriesByParentID(array $valueCategories): array
+    public function sortValueCategoriesByParentID(array $valueCategories)
     {
         usort($valueCategories, [$this, 'compare']);
 
@@ -130,7 +130,7 @@ class ShopwareCategoryHelper extends AbstractHelper {
      *
      * @return int
      */
-    private function compare($cat1, $cat2): int
+    private function compare($cat1, $cat2)
     {
         return ($cat1->getParentIdentifier() > $cat2->getParentIdentifier()) ? 1 : -1;
     }

--- a/Services/ReadData/External/ReadCategoriesService.php
+++ b/Services/ReadData/External/ReadCategoriesService.php
@@ -91,7 +91,7 @@ class ReadCategoriesService extends AbstractReadDataService implements ReadDataI
      *
      * @return array
      */
-    public function read(array $filter): array
+    public function read(array $filter)
     {
         /** @var ApiClient $api */
         $api = new ApiClient($this->apiConfig);

--- a/Services/ReadData/External/ReadProductsService.php
+++ b/Services/ReadData/External/ReadProductsService.php
@@ -17,7 +17,7 @@ class ReadProductsService extends AbstractReadDataService implements ReadDataInt
      *
      * @return ValueArticle[]
      */
-    public function get(array $filter): array
+    public function get(array $filter)
     {
         $data = $this->read($filter);
 
@@ -31,7 +31,7 @@ class ReadProductsService extends AbstractReadDataService implements ReadDataInt
      *
      * @return ValueArticle[]
      */
-    public function transform(array $products): array
+    public function transform(array $products)
     {
         $this->logger->debug('Receiving products from afterbuy', $products);
 
@@ -132,7 +132,7 @@ class ReadProductsService extends AbstractReadDataService implements ReadDataInt
      *
      * @return array
      */
-    public function read(array $filter): array
+    public function read(array $filter)
     {
 
         $resource = new ApiClient($this->apiConfig);

--- a/Services/ReadData/Internal/ReadCategoriesService.php
+++ b/Services/ReadData/Internal/ReadCategoriesService.php
@@ -27,7 +27,7 @@ class ReadCategoriesService extends AbstractReadDataService implements ReadDataI
      *
      * @return ValueCategory[]
      */
-    public function get(array $filter): array
+    public function get(array $filter)
     {
         $data = $this->read($filter);
 
@@ -41,7 +41,7 @@ class ReadCategoriesService extends AbstractReadDataService implements ReadDataI
      *
      * @return ValueCategory[]
      */
-    public function transform(array $shopwareCategories): array
+    public function transform(array $shopwareCategories)
     {
         $this->logger->debug('Receiving categories from shop', $shopwareCategories);
 
@@ -100,7 +100,7 @@ class ReadCategoriesService extends AbstractReadDataService implements ReadDataI
      *
      * @return ShopwareCategory[]
      */
-    public function read(array $filter): array
+    public function read(array $filter)
     {
         /**
          * @var ShopwareCategoryHelper $categoryHelper

--- a/Services/ReadData/Internal/ReadStatusService.php
+++ b/Services/ReadData/Internal/ReadStatusService.php
@@ -16,14 +16,14 @@ use Shopware\Models\Order\Order;
 class ReadStatusService extends AbstractReadDataService implements ReadDataInterface
 {
 
-    public function get(array $filter): array
+    public function get(array $filter)
     {
         $data = $this->read($filter);
 
         return $this->transform($data);
     }
 
-    public function transform(array $orders): array
+    public function transform(array $orders)
     {
         $this->logger->debug('Receiving updated orders from shop', $orders);
 
@@ -57,7 +57,7 @@ class ReadStatusService extends AbstractReadDataService implements ReadDataInter
     }
 
 
-    public function read(array $filter): array
+    public function read(array $filter)
     {
         /**
          * @var ShopwareOrderHelper $orderHelper

--- a/Services/WriteData/External/WriteCategoriesService.php
+++ b/Services/WriteData/External/WriteCategoriesService.php
@@ -44,7 +44,7 @@ class WriteCategoriesService extends AbstractWriteDataService implements WriteDa
      *
      * @return array
      */
-    public function transform(array $valueCategories): array
+    public function transform(array $valueCategories)
     {
         $this->logger->debug('Got ' . count($valueCategories) . ' items', [$valueCategories]);
         return $this->helper->buildAfterbuyCatalogStructure($valueCategories);

--- a/Services/WriteData/External/WriteStatusService.php
+++ b/Services/WriteData/External/WriteStatusService.php
@@ -25,7 +25,7 @@ class WriteStatusService extends AbstractWriteDataService implements WriteDataIn
         return $this->send($catalogs);
     }
 
-    public function transform(array $orders): array
+    public function transform(array $orders)
     {
         $this->logger->debug("Storing " . count($orders) . " items.", array($orders));
 

--- a/Services/WriteData/Internal/WriteProductsService.php
+++ b/Services/WriteData/Internal/WriteProductsService.php
@@ -352,7 +352,7 @@ class WriteProductsService extends AbstractWriteDataService implements WriteData
         Media $media,
         ProductPicture $productPicture,
         ShopwareArticle $article
-    ): ArticleImage {
+    ) {
         $image = new ArticleImage();
 
         $image->setArticle($article);
@@ -378,7 +378,7 @@ class WriteProductsService extends AbstractWriteDataService implements WriteData
      *
      * @return ArticleImage
      */
-    public function createChildImage(ArticleImage $parent, ArticleDetail $detail): ArticleImage
+    public function createChildImage(ArticleImage $parent, ArticleDetail $detail)
     {
         $image = new ArticleImage();
 

--- a/ValueObjects/Address.php
+++ b/ValueObjects/Address.php
@@ -135,7 +135,7 @@ class Address extends AbstractValueObject
     /**
      * @return \DateTime
      */
-    public function getBirthday(): ?\DateTime
+    public function getBirthday()
     {
         return $this->birthday;
     }
@@ -143,7 +143,7 @@ class Address extends AbstractValueObject
     /**
      * @param \DateTime $birthday
      */
-    public function setBirthday(\DateTime $birthday): void
+    public function setBirthday(\DateTime $birthday)
     {
         $this->birthday = $birthday;
     }
@@ -153,7 +153,7 @@ class Address extends AbstractValueObject
     /**
      * @return string
      */
-    public function getCompany(): string
+    public function getCompany()
     {
         return $this->company;
     }
@@ -161,7 +161,7 @@ class Address extends AbstractValueObject
     /**
      * @param string $company
      */
-    public function setCompany(string $company): void
+    public function setCompany(string $company)
     {
         $this->company = $company;
     }
@@ -169,7 +169,7 @@ class Address extends AbstractValueObject
     /**
      * @return string
      */
-    public function getDepartment(): string
+    public function getDepartment()
     {
         return $this->department;
     }
@@ -177,7 +177,7 @@ class Address extends AbstractValueObject
     /**
      * @param string $department
      */
-    public function setDepartment(string $department): void
+    public function setDepartment(string $department)
     {
         $this->department = $department;
     }
@@ -185,7 +185,7 @@ class Address extends AbstractValueObject
     /**
      * @return string
      */
-    public function getSalutation(): string
+    public function getSalutation()
     {
         return $this->salutation;
     }
@@ -193,7 +193,7 @@ class Address extends AbstractValueObject
     /**
      * @param string $salutation
      */
-    public function setSalutation(string $salutation): void
+    public function setSalutation(string $salutation)
     {
         $this->salutation = $salutation;
     }
@@ -201,7 +201,7 @@ class Address extends AbstractValueObject
     /**
      * @return string
      */
-    public function getFirstname(): string
+    public function getFirstname()
     {
         return $this->firstname;
     }
@@ -209,7 +209,7 @@ class Address extends AbstractValueObject
     /**
      * @param string $firstname
      */
-    public function setFirstname(string $firstname): void
+    public function setFirstname(string $firstname)
     {
         $this->firstname = $firstname;
     }
@@ -217,7 +217,7 @@ class Address extends AbstractValueObject
     /**
      * @return string
      */
-    public function getTitle(): string
+    public function getTitle()
     {
         return $this->title;
     }
@@ -225,7 +225,7 @@ class Address extends AbstractValueObject
     /**
      * @param string $title
      */
-    public function setTitle(string $title): void
+    public function setTitle(string $title)
     {
         $this->title = $title;
     }
@@ -233,7 +233,7 @@ class Address extends AbstractValueObject
     /**
      * @return string
      */
-    public function getLastname(): string
+    public function getLastname()
     {
         return $this->lastname;
     }
@@ -241,7 +241,7 @@ class Address extends AbstractValueObject
     /**
      * @param string $lastname
      */
-    public function setLastname(string $lastname): void
+    public function setLastname(string $lastname)
     {
         $this->lastname = $lastname;
     }
@@ -249,7 +249,7 @@ class Address extends AbstractValueObject
     /**
      * @return string
      */
-    public function getStreet(): string
+    public function getStreet()
     {
         return $this->street;
     }
@@ -257,7 +257,7 @@ class Address extends AbstractValueObject
     /**
      * @param string $street
      */
-    public function setStreet(string $street): void
+    public function setStreet(string $street)
     {
         $this->street = $street;
     }
@@ -265,7 +265,7 @@ class Address extends AbstractValueObject
     /**
      * @return string
      */
-    public function getZipcode(): string
+    public function getZipcode()
     {
         return $this->zipcode;
     }
@@ -273,7 +273,7 @@ class Address extends AbstractValueObject
     /**
      * @param string $zipcode
      */
-    public function setZipcode(string $zipcode): void
+    public function setZipcode(string $zipcode)
     {
         $this->zipcode = $zipcode;
     }
@@ -281,7 +281,7 @@ class Address extends AbstractValueObject
     /**
      * @return string
      */
-    public function getCity(): string
+    public function getCity()
     {
         return $this->city;
     }
@@ -289,7 +289,7 @@ class Address extends AbstractValueObject
     /**
      * @param string $city
      */
-    public function setCity(string $city): void
+    public function setCity(string $city)
     {
         $this->city = $city;
     }
@@ -297,7 +297,7 @@ class Address extends AbstractValueObject
     /**
      * @return string
      */
-    public function getPhone(): string
+    public function getPhone()
     {
         return $this->phone;
     }
@@ -305,7 +305,7 @@ class Address extends AbstractValueObject
     /**
      * @param string $phone
      */
-    public function setPhone(string $phone): void
+    public function setPhone(string $phone)
     {
         $this->phone = $phone;
     }
@@ -313,7 +313,7 @@ class Address extends AbstractValueObject
     /**
      * @return string
      */
-    public function getVatId(): string
+    public function getVatId()
     {
         return $this->vatId;
     }
@@ -321,7 +321,7 @@ class Address extends AbstractValueObject
     /**
      * @param string $vatId
      */
-    public function setVatId(?string $vatId): void
+    public function setVatId(?string $vatId)
     {
         if(!$vatId) {
             $vatId = "";
@@ -333,7 +333,7 @@ class Address extends AbstractValueObject
     /**
      * @return string
      */
-    public function getAdditionalAddressLine1(): string
+    public function getAdditionalAddressLine1()
     {
         return $this->additionalAddressLine1;
     }
@@ -341,7 +341,7 @@ class Address extends AbstractValueObject
     /**
      * @param string $additionalAddressLine1
      */
-    public function setAdditionalAddressLine1(string $additionalAddressLine1): void
+    public function setAdditionalAddressLine1(string $additionalAddressLine1)
     {
         $this->additionalAddressLine1 = $additionalAddressLine1;
     }
@@ -349,7 +349,7 @@ class Address extends AbstractValueObject
     /**
      * @return string
      */
-    public function getAdditionalAddressLine2(): string
+    public function getAdditionalAddressLine2()
     {
         return $this->additionalAddressLine2;
     }
@@ -357,7 +357,7 @@ class Address extends AbstractValueObject
     /**
      * @param string $additionalAddressLine2
      */
-    public function setAdditionalAddressLine2(string $additionalAddressLine2): void
+    public function setAdditionalAddressLine2(string $additionalAddressLine2)
     {
         if(!$additionalAddressLine2) {
             $additionalAddressLine2 = "";
@@ -369,7 +369,7 @@ class Address extends AbstractValueObject
     /**
      * @return string
      */
-    public function getCountry(): string
+    public function getCountry()
     {
         return $this->country;
     }
@@ -377,7 +377,7 @@ class Address extends AbstractValueObject
     /**
      * @param string $country
      */
-    public function setCountry(string $country): void
+    public function setCountry(string $country)
     {
         $this->country = $country;
     }
@@ -385,7 +385,7 @@ class Address extends AbstractValueObject
     /**
      * @return string
      */
-    public function getEmail(): string
+    public function getEmail()
     {
         return $this->email;
     }
@@ -393,7 +393,7 @@ class Address extends AbstractValueObject
     /**
      * @param string $email
      */
-    public function setEmail(?string $email): void
+    public function setEmail(?string $email)
     {
         if(!$email) {
             return;

--- a/ValueObjects/Article.php
+++ b/ValueObjects/Article.php
@@ -79,7 +79,7 @@ class Article extends AbstractValueObject
     /**
      * @return array
      */
-    public function getExternalCategoryIds(): array
+    public function getExternalCategoryIds()
     {
         return $this->externalCategoryIds;
     }
@@ -87,7 +87,7 @@ class Article extends AbstractValueObject
     /**
      * @param array $externalCategoryIds
      */
-    public function setExternalCategoryIds(array $externalCategoryIds): void
+    public function setExternalCategoryIds(array $externalCategoryIds)
     {
         $this->externalCategoryIds = $externalCategoryIds;
     }
@@ -96,7 +96,7 @@ class Article extends AbstractValueObject
     /**
      * @return string
      */
-    public function getMainImageThumbnailUrl(): ?string
+    public function getMainImageThumbnailUrl()
     {
         return $this->mainImageThumbnailUrl;
     }
@@ -104,7 +104,7 @@ class Article extends AbstractValueObject
     /**
      * @param string $mainImageThumbnailUrl
      */
-    public function setMainImageThumbnailUrl(string $mainImageThumbnailUrl): void
+    public function setMainImageThumbnailUrl(string $mainImageThumbnailUrl)
     {
         $this->mainImageThumbnailUrl = $mainImageThumbnailUrl;
     }
@@ -120,7 +120,7 @@ class Article extends AbstractValueObject
     /**
      * @return string
      */
-    public function getMainImageUrl(): ?string
+    public function getMainImageUrl()
     {
         return $this->mainImageUrl;
     }
@@ -128,7 +128,7 @@ class Article extends AbstractValueObject
     /**
      * @param string $mainImageUrl
      */
-    public function setMainImageUrl(string $mainImageUrl): void
+    public function setMainImageUrl(string $mainImageUrl)
     {
         $this->mainImageUrl = $mainImageUrl;
     }
@@ -136,7 +136,7 @@ class Article extends AbstractValueObject
     /**
      * @param mixed $variantId
      */
-    public function setVariantId($variantId): void
+    public function setVariantId($variantId)
     {
         $this->variantId = $variantId;
     }
@@ -162,7 +162,7 @@ class Article extends AbstractValueObject
     /**
      * @param mixed $shortDescription
      */
-    public function setShortDescription($shortDescription): void
+    public function setShortDescription($shortDescription)
     {
         $this->shortDescription = $shortDescription;
     }
@@ -178,7 +178,7 @@ class Article extends AbstractValueObject
     /**
      * @param mixed $supplierNumber
      */
-    public function setSupplierNumber($supplierNumber): void
+    public function setSupplierNumber($supplierNumber)
     {
         $this->supplierNumber = $supplierNumber;
     }
@@ -192,7 +192,7 @@ class Article extends AbstractValueObject
     /**
      * @return ArrayCollection
      */
-    public function getVariantArticles(): ?ArrayCollection
+    public function getVariantArticles()
     {
         return $this->variantArticles;
     }
@@ -200,7 +200,7 @@ class Article extends AbstractValueObject
     /**
      * @param ArrayCollection $variantArticles
      */
-    public function setVariantArticles(?ArrayCollection $variantArticles): void
+    public function setVariantArticles(?ArrayCollection $variantArticles)
     {
         $this->variantArticles = $variantArticles;
     }
@@ -216,7 +216,7 @@ class Article extends AbstractValueObject
     /**
      * @param mixed $description
      */
-    public function setDescription($description): void
+    public function setDescription($description)
     {
         $this->description = $description;
     }
@@ -224,7 +224,7 @@ class Article extends AbstractValueObject
     /**
      * @return bool
      */
-    public function isActive(): bool
+    public function isActive()
     {
         return $this->active;
     }
@@ -232,7 +232,7 @@ class Article extends AbstractValueObject
     /**
      * @param bool $active
      */
-    public function setActive(bool $active): void
+    public function setActive(bool $active)
     {
         $this->active = $active;
     }
@@ -249,7 +249,7 @@ class Article extends AbstractValueObject
     /**
      * @param mixed $mainArticleId
      */
-    public function setMainArticleId($mainArticleId): void
+    public function setMainArticleId($mainArticleId)
     {
         $this->mainArticleId = $mainArticleId;
     }
@@ -257,7 +257,7 @@ class Article extends AbstractValueObject
     /**
      * @return array
      */
-    public function getVariants(): array
+    public function getVariants()
     {
         return $this->variants;
     }
@@ -265,7 +265,7 @@ class Article extends AbstractValueObject
     /**
      * @param array $variants
      */
-    public function setVariants(array $variants): void
+    public function setVariants(array $variants)
     {
         $this->variants = $variants;
     }
@@ -281,7 +281,7 @@ class Article extends AbstractValueObject
     /**
      * @param mixed $pseudoPrice
      */
-    public function setPseudoPrice($pseudoPrice): void
+    public function setPseudoPrice($pseudoPrice)
     {
         $this->pseudoPrice = $pseudoPrice;
     }
@@ -297,7 +297,7 @@ class Article extends AbstractValueObject
     /**
      * @param mixed $tax
      */
-    public function setTax($tax): void
+    public function setTax($tax)
     {
         $this->tax = $tax;
     }
@@ -313,7 +313,7 @@ class Article extends AbstractValueObject
     /**
      * @param mixed $stockMin
      */
-    public function setStockMin($stockMin): void
+    public function setStockMin($stockMin)
     {
         $this->stockMin = $stockMin;
     }
@@ -322,7 +322,7 @@ class Article extends AbstractValueObject
     /**
      * @return string
      */
-    public function getExternalIdentifier(): ?string
+    public function getExternalIdentifier()
     {
         return $this->externalIdentifier;
     }
@@ -330,7 +330,7 @@ class Article extends AbstractValueObject
     /**
      * @param string $externalIdentifier
      */
-    public function setExternalIdentifier(?string $externalIdentifier): void
+    public function setExternalIdentifier(?string $externalIdentifier)
     {
         $this->externalIdentifier = $externalIdentifier;
     }
@@ -338,7 +338,7 @@ class Article extends AbstractValueObject
     /**
      * @return string
      */
-    public function getInternalIdentifier(): string
+    public function getInternalIdentifier()
     {
         return $this->internalIdentifier;
     }
@@ -346,7 +346,7 @@ class Article extends AbstractValueObject
     /**
      * @param string $internalIdentifier
      */
-    public function setInternalIdentifier(string $internalIdentifier): void
+    public function setInternalIdentifier(string $internalIdentifier)
     {
         $this->internalIdentifier = $internalIdentifier;
     }
@@ -354,7 +354,7 @@ class Article extends AbstractValueObject
     /**
      * @return int
      */
-    public function getStock(): ?int
+    public function getStock()
     {
         return $this->stock;
     }
@@ -362,7 +362,7 @@ class Article extends AbstractValueObject
     /**
      * @param int $stock
      */
-    public function setStock(?int $stock): void
+    public function setStock(?int $stock)
     {
         $this->stock = $stock;
     }
@@ -370,7 +370,7 @@ class Article extends AbstractValueObject
     /**
      * @return string
      */
-    public function getName(): string
+    public function getName()
     {
         return $this->name;
     }
@@ -378,7 +378,7 @@ class Article extends AbstractValueObject
     /**
      * @param string $name
      */
-    public function setName(string $name): void
+    public function setName(string $name)
     {
         $this->name = $name;
     }
@@ -386,7 +386,7 @@ class Article extends AbstractValueObject
     /**
      * @return float
      */
-    public function getPrice(): float
+    public function getPrice()
     {
         return $this->price;
     }
@@ -394,7 +394,7 @@ class Article extends AbstractValueObject
     /**
      * @param float $price
      */
-    public function setPrice(float $price): void
+    public function setPrice(float $price)
     {
         $this->price = $price;
     }
@@ -402,7 +402,7 @@ class Article extends AbstractValueObject
     /**
      * @return string
      */
-    public function getManufacturer(): string
+    public function getManufacturer()
     {
         return $this->manufacturer;
     }
@@ -410,7 +410,7 @@ class Article extends AbstractValueObject
     /**
      * @param string $manufacturer
      */
-    public function setManufacturer(string $manufacturer): void
+    public function setManufacturer(string $manufacturer)
     {
         $this->manufacturer = $manufacturer;
     }
@@ -418,7 +418,7 @@ class Article extends AbstractValueObject
     /**
      * @return string
      */
-    public function getEan(): ?string
+    public function getEan()
     {
         return $this->ean;
     }
@@ -426,7 +426,7 @@ class Article extends AbstractValueObject
     /**
      * @param string $ean
      */
-    public function setEan(?string $ean): void
+    public function setEan(?string $ean)
     {
         $this->ean = $ean;
     }
@@ -434,7 +434,7 @@ class Article extends AbstractValueObject
     /**
      * @return ProductPicture[]
      */
-    public function getProductPictures(): array
+    public function getProductPictures()
     {
         return $this->productPictures;
     }
@@ -442,12 +442,12 @@ class Article extends AbstractValueObject
     /**
      * @param ProductPicture $productPicture
      */
-    public function addProductPicture(ProductPicture $productPicture): void
+    public function addProductPicture(ProductPicture $productPicture)
     {
         $this->productPictures[] = $productPicture;
     }
 
-    public function isMainProduct(): bool
+    public function isMainProduct()
     {
         return $this->mainArticleId === null;
     }

--- a/ValueObjects/Category.php
+++ b/ValueObjects/Category.php
@@ -61,7 +61,7 @@ class Category extends AbstractValueObject
     /**
      * @return string
      */
-    public function getName(): string
+    public function getName()
     {
         return $this->name;
     }
@@ -69,7 +69,7 @@ class Category extends AbstractValueObject
     /**
      * @param $name
      */
-    public function setName($name): void
+    public function setName($name)
     {
         $this->name = $name;
     }
@@ -77,7 +77,7 @@ class Category extends AbstractValueObject
     /**
      * @return string
      */
-    public function getExternalIdentifier(): ?string
+    public function getExternalIdentifier()
     {
         return $this->externalIdentifier;
     }
@@ -85,7 +85,7 @@ class Category extends AbstractValueObject
     /**
      * @param $externalIdentifier
      */
-    public function setExternalIdentifier(?string $externalIdentifier): void
+    public function setExternalIdentifier(?string $externalIdentifier)
     {
         $this->externalIdentifier = $externalIdentifier;
     }
@@ -93,7 +93,7 @@ class Category extends AbstractValueObject
     /**
      * @return string
      */
-    public function getInternalIdentifier(): string
+    public function getInternalIdentifier()
     {
         return $this->internalIdentifier;
     }
@@ -101,7 +101,7 @@ class Category extends AbstractValueObject
     /**
      * @param $internalIdentifier
      */
-    public function setInternalIdentifier($internalIdentifier): void
+    public function setInternalIdentifier($internalIdentifier)
     {
         $this->internalIdentifier = $internalIdentifier;
     }
@@ -109,7 +109,7 @@ class Category extends AbstractValueObject
     /**
      * @return string
      */
-    public function getParentIdentifier(): string
+    public function getParentIdentifier()
     {
         return $this->parentIdentifier;
     }
@@ -117,7 +117,7 @@ class Category extends AbstractValueObject
     /**
      * @param $parentIdentifier
      */
-    public function setParentIdentifier($parentIdentifier): void
+    public function setParentIdentifier($parentIdentifier)
     {
         $this->parentIdentifier = $parentIdentifier;
     }
@@ -125,7 +125,7 @@ class Category extends AbstractValueObject
     /**
      * @return string
      */
-    public function getDescription(): string
+    public function getDescription()
     {
         return $this->description;
     }
@@ -133,7 +133,7 @@ class Category extends AbstractValueObject
     /**
      * @param $description
      */
-    public function setDescription(?string $description): void
+    public function setDescription(?string $description)
     {
         if ($description !== null) {
             $this->description = $description;
@@ -143,7 +143,7 @@ class Category extends AbstractValueObject
     /**
      * @return string
      */
-    public function getPosition(): string
+    public function getPosition()
     {
         return $this->position;
     }
@@ -151,7 +151,7 @@ class Category extends AbstractValueObject
     /**
      * @param string $position
      */
-    public function setPosition(?string $position): void
+    public function setPosition(?string $position)
     {
         if ($position !== null) {
             $this->position = $position;
@@ -161,7 +161,7 @@ class Category extends AbstractValueObject
     /**
      * @return bool
      */
-    public function getActive(): bool
+    public function getActive()
     {
         return $this->active;
     }
@@ -169,7 +169,7 @@ class Category extends AbstractValueObject
     /**
      * @param $active
      */
-    public function setActive($active): void
+    public function setActive($active)
     {
         $this->active = $active;
     }
@@ -177,7 +177,7 @@ class Category extends AbstractValueObject
     /**
      * @return string
      */
-    public function getImage(): string
+    public function getImage()
     {
         return $this->image;
     }
@@ -185,7 +185,7 @@ class Category extends AbstractValueObject
     /**
      * @param $image
      */
-    public function setImage($image): void
+    public function setImage($image)
     {
         $this->image = $image;
     }
@@ -193,7 +193,7 @@ class Category extends AbstractValueObject
     /**
      * @return string
      */
-    public function getCmsText(): string
+    public function getCmsText()
     {
         return $this->cmsText;
     }
@@ -201,7 +201,7 @@ class Category extends AbstractValueObject
     /**
      * @param string $cmsText
      */
-    public function setCmsText(?string $cmsText): void
+    public function setCmsText(?string $cmsText)
     {
         if ($cmsText !== null) {
            $this->cmsText = $cmsText;
@@ -211,7 +211,7 @@ class Category extends AbstractValueObject
     /**
      * @return string
      */
-    public function getPath(): string
+    public function getPath()
     {
         return $this->path;
     }
@@ -219,7 +219,7 @@ class Category extends AbstractValueObject
     /**
      * @param string $path
      */
-    public function setPath(?string $path): void
+    public function setPath(?string $path)
     {
         if ($path !== null) {
             $this->path = $path;
@@ -229,7 +229,7 @@ class Category extends AbstractValueObject
     /**
      * @return bool
      */
-    public function isValid(): bool
+    public function isValid()
     {
         $isValid = true;
 

--- a/ValueObjects/Order.php
+++ b/ValueObjects/Order.php
@@ -115,7 +115,7 @@ class Order extends AbstractValueObject {
     /**
      * @return bool
      */
-    public function isCleared(): bool
+    public function isCleared()
     {
         return $this->cleared;
     }
@@ -123,7 +123,7 @@ class Order extends AbstractValueObject {
     /**
      * @param bool $cleared
      */
-    public function setCleared(bool $cleared): void
+    public function setCleared(bool $cleared)
     {
         $this->cleared = $cleared;
     }
@@ -131,7 +131,7 @@ class Order extends AbstractValueObject {
     /**
      * @return int
      */
-    public function getPaymentTypeId(): int
+    public function getPaymentTypeId()
     {
         return $this->paymentTypeId;
     }
@@ -139,7 +139,7 @@ class Order extends AbstractValueObject {
     /**
      * @param int $paymentTypeId
      */
-    public function setPaymentTypeId(int $paymentTypeId): void
+    public function setPaymentTypeId(int $paymentTypeId)
     {
         $this->paymentTypeId = $paymentTypeId;
     }
@@ -149,7 +149,7 @@ class Order extends AbstractValueObject {
     /**
      * @return string
      */
-    public function getShippingType(): string
+    public function getShippingType()
     {
         return $this->shippingType;
     }
@@ -157,7 +157,7 @@ class Order extends AbstractValueObject {
     /**
      * @param string $shippingType
      */
-    public function setShippingType(string $shippingType): void
+    public function setShippingType(string $shippingType)
     {
         $this->shippingType = $shippingType;
     }
@@ -175,7 +175,7 @@ class Order extends AbstractValueObject {
     /**
      * @param mixed $customerNumber
      */
-    public function setCustomerNumber($customerNumber): void
+    public function setCustomerNumber($customerNumber)
     {
         $this->customerNumber = $customerNumber;
     }
@@ -187,7 +187,7 @@ class Order extends AbstractValueObject {
     /**
      * @return string
      */
-    public function getPaymentType(): string
+    public function getPaymentType()
     {
         return $this->paymentType;
     }
@@ -195,7 +195,7 @@ class Order extends AbstractValueObject {
     /**
      * @param string $paymentType
      */
-    public function setPaymentType(string $paymentType): void
+    public function setPaymentType(string $paymentType)
     {
         $this->paymentType = $paymentType;
     }
@@ -208,7 +208,7 @@ class Order extends AbstractValueObject {
     /**
      * @return string
      */
-    public function getExternalIdentifier(): string
+    public function getExternalIdentifier()
     {
         return $this->externalIdentifier;
     }
@@ -216,7 +216,7 @@ class Order extends AbstractValueObject {
     /**
      * @param string $externalIdentifier
      */
-    public function setExternalIdentifier(string $externalIdentifier): void
+    public function setExternalIdentifier(string $externalIdentifier)
     {
         $this->externalIdentifier = $externalIdentifier;
     }
@@ -224,7 +224,7 @@ class Order extends AbstractValueObject {
     /**
      * @return int
      */
-    public function getInternalIdentifier(): int
+    public function getInternalIdentifier()
     {
         return $this->internalIdentifier;
     }
@@ -232,7 +232,7 @@ class Order extends AbstractValueObject {
     /**
      * @param int $internalIdentifier
      */
-    public function setInternalIdentifier(int $internalIdentifier): void
+    public function setInternalIdentifier(int $internalIdentifier)
     {
         $this->internalIdentifier = $internalIdentifier;
     }
@@ -240,7 +240,7 @@ class Order extends AbstractValueObject {
     /**
      * @return ArrayCollection
      */
-    public function getPositions(): ArrayCollection
+    public function getPositions()
     {
         return $this->positions;
     }
@@ -248,7 +248,7 @@ class Order extends AbstractValueObject {
     /**
      * @param ArrayCollection $positions
      */
-    public function setPositions(ArrayCollection $positions): void
+    public function setPositions(ArrayCollection $positions)
     {
         $this->positions = $positions;
     }
@@ -256,7 +256,7 @@ class Order extends AbstractValueObject {
     /**
      * @return Address
      */
-    public function getShippingAddress(): ?Address
+    public function getShippingAddress()
     {
         return $this->shippingAddress;
     }
@@ -264,7 +264,7 @@ class Order extends AbstractValueObject {
     /**
      * @param Address $shippingAddress
      */
-    public function setShippingAddress(Address $shippingAddress): void
+    public function setShippingAddress(Address $shippingAddress)
     {
         $this->shippingAddress = $shippingAddress;
     }
@@ -272,7 +272,7 @@ class Order extends AbstractValueObject {
     /**
      * @return Address
      */
-    public function getBillingAddress(): Address
+    public function getBillingAddress()
     {
         return $this->billingAddress;
     }
@@ -280,7 +280,7 @@ class Order extends AbstractValueObject {
     /**
      * @param Address $billingAddress
      */
-    public function setBillingAddress(Address $billingAddress): void
+    public function setBillingAddress(Address $billingAddress)
     {
         $this->billingAddress = $billingAddress;
     }
@@ -296,7 +296,7 @@ class Order extends AbstractValueObject {
     /**
      * @param mixed $amount
      */
-    public function setAmount(float $amount): void
+    public function setAmount(float $amount)
     {
         $this->amount = $amount;
     }
@@ -304,7 +304,7 @@ class Order extends AbstractValueObject {
     /**
      * @return float
      */
-    public function getShipping(): float
+    public function getShipping()
     {
         return $this->shipping;
     }
@@ -312,7 +312,7 @@ class Order extends AbstractValueObject {
     /**
      * @param float $shipping
      */
-    public function setShipping(float $shipping): void
+    public function setShipping(float $shipping)
     {
         $this->shipping = $shipping;
     }
@@ -320,7 +320,7 @@ class Order extends AbstractValueObject {
     /**
      * @return float
      */
-    public function getAmountNet(): float
+    public function getAmountNet()
     {
         return $this->amountNet;
     }
@@ -328,7 +328,7 @@ class Order extends AbstractValueObject {
     /**
      * @param float $amountNet
      */
-    public function setAmountNet(float $amountNet): void
+    public function setAmountNet(float $amountNet)
     {
         $this->amountNet = $amountNet;
     }
@@ -336,7 +336,7 @@ class Order extends AbstractValueObject {
     /**
      * @return float
      */
-    public function getPaid(): float
+    public function getPaid()
     {
         return $this->paid;
     }
@@ -344,7 +344,7 @@ class Order extends AbstractValueObject {
     /**
      * @param float $paid
      */
-    public function setPaid(float $paid): void
+    public function setPaid(float $paid)
     {
         $this->paid = $paid;
     }
@@ -352,7 +352,7 @@ class Order extends AbstractValueObject {
     /**
      * @return string
      */
-    public function getCurrency(): string
+    public function getCurrency()
     {
         return $this->currency;
     }
@@ -360,7 +360,7 @@ class Order extends AbstractValueObject {
     /**
      * @param string $currency
      */
-    public function setCurrency(string $currency): void
+    public function setCurrency(string $currency)
     {
         $this->currency = $currency;
     }
@@ -368,7 +368,7 @@ class Order extends AbstractValueObject {
     /**
      * @return string
      */
-    public function getTransactionId(): string
+    public function getTransactionId()
     {
         return $this->transactionId;
     }
@@ -376,7 +376,7 @@ class Order extends AbstractValueObject {
     /**
      * @param string $transactionId
      */
-    public function setTransactionId(string $transactionId): void
+    public function setTransactionId(string $transactionId)
     {
         $this->transactionId = $transactionId;
     }
@@ -384,7 +384,7 @@ class Order extends AbstractValueObject {
     /**
      * @return bool
      */
-    public function isTaxFree(): bool
+    public function isTaxFree()
     {
         return $this->taxFree;
     }
@@ -392,7 +392,7 @@ class Order extends AbstractValueObject {
     /**
      * @param bool $taxFree
      */
-    public function setTaxFree(bool $taxFree): void
+    public function setTaxFree(bool $taxFree)
     {
         $this->taxFree = $taxFree;
     }
@@ -408,7 +408,7 @@ class Order extends AbstractValueObject {
     /**
      * @param float $shippingNet
      */
-    public function setShippingNet(float $shippingNet): void
+    public function setShippingNet(float $shippingNet)
     {
         $this->shippingNet = $shippingNet;
     }
@@ -416,7 +416,7 @@ class Order extends AbstractValueObject {
     /**
      * @return float
      */
-    public function getShippingTax(): float
+    public function getShippingTax()
     {
         return $this->shippingTax;
     }
@@ -424,7 +424,7 @@ class Order extends AbstractValueObject {
     /**
      * @param float $shippingTax
      */
-    public function setShippingTax(float $shippingTax): void
+    public function setShippingTax(float $shippingTax)
     {
         $this->shippingTax = $shippingTax;
     }
@@ -432,7 +432,7 @@ class Order extends AbstractValueObject {
     /**
      * @return bool
      */
-    public function isShipped(): bool
+    public function isShipped()
     {
         return $this->shipped;
     }
@@ -440,7 +440,7 @@ class Order extends AbstractValueObject {
     /**
      * @param bool $shipped
      */
-    public function setShipped(bool $shipped): void
+    public function setShipped(bool $shipped)
     {
         $this->shipped = $shipped;
     }
@@ -448,7 +448,7 @@ class Order extends AbstractValueObject {
     /**
      * @return \DateTime
      */
-    public function getCreateDate(): \DateTime
+    public function getCreateDate()
     {
         return $this->createDate;
     }
@@ -456,7 +456,7 @@ class Order extends AbstractValueObject {
     /**
      * @param \DateTime $createDate
      */
-    public function setCreateDate(\DateTime $createDate): void
+    public function setCreateDate(\DateTime $createDate)
     {
         $this->createDate = $createDate;
     }
@@ -464,7 +464,7 @@ class Order extends AbstractValueObject {
     /**
      * @return \DateTime
      */
-    public function getUpdateDate(): \DateTime
+    public function getUpdateDate()
     {
         return $this->updateDate;
     }
@@ -472,7 +472,7 @@ class Order extends AbstractValueObject {
     /**
      * @param \DateTime $updateDate
      */
-    public function setUpdateDate(\DateTime $updateDate): void
+    public function setUpdateDate(\DateTime $updateDate)
     {
         $this->updateDate = $updateDate;
     }

--- a/ValueObjects/OrderPosition.php
+++ b/ValueObjects/OrderPosition.php
@@ -38,7 +38,7 @@ class OrderPosition extends AbstractValueObject {
     /**
      * @return float
      */
-    public function getPrice(): float
+    public function getPrice()
     {
         return $this->price;
     }
@@ -46,7 +46,7 @@ class OrderPosition extends AbstractValueObject {
     /**
      * @param float $price
      */
-    public function setPrice(float $price): void
+    public function setPrice(float $price)
     {
         $this->price = $price;
     }
@@ -54,7 +54,7 @@ class OrderPosition extends AbstractValueObject {
     /**
      * @return string
      */
-    public function getOrderId(): string
+    public function getOrderId()
     {
         return $this->orderId;
     }
@@ -62,7 +62,7 @@ class OrderPosition extends AbstractValueObject {
     /**
      * @param string $orderId
      */
-    public function setOrderId(string $orderId): void
+    public function setOrderId(string $orderId)
     {
         $this->orderId = $orderId;
     }
@@ -70,7 +70,7 @@ class OrderPosition extends AbstractValueObject {
     /**
      * @return string
      */
-    public function getName(): string
+    public function getName()
     {
         return $this->name;
     }
@@ -78,7 +78,7 @@ class OrderPosition extends AbstractValueObject {
     /**
      * @param string $name
      */
-    public function setName(string $name): void
+    public function setName(string $name)
     {
         $this->name = $name;
     }
@@ -86,7 +86,7 @@ class OrderPosition extends AbstractValueObject {
     /**
      * @return string
      */
-    public function getInternalIdentifier(): ?string
+    public function getInternalIdentifier()
     {
         return $this->internalIdentifier;
     }
@@ -94,7 +94,7 @@ class OrderPosition extends AbstractValueObject {
     /**
      * @param string $internalIdentifier
      */
-    public function setInternalIdentifier(string $internalIdentifier): void
+    public function setInternalIdentifier(string $internalIdentifier)
     {
         $this->internalIdentifier = $internalIdentifier;
     }
@@ -102,7 +102,7 @@ class OrderPosition extends AbstractValueObject {
     /**
      * @return string
      */
-    public function getExternalIdentifier(): ?string
+    public function getExternalIdentifier()
     {
         return $this->externalIdentifier;
     }
@@ -110,7 +110,7 @@ class OrderPosition extends AbstractValueObject {
     /**
      * @param string $externalIdentifier
      */
-    public function setExternalIdentifier(string $externalIdentifier): void
+    public function setExternalIdentifier(string $externalIdentifier)
     {
         $this->externalIdentifier = $externalIdentifier;
     }
@@ -126,7 +126,7 @@ class OrderPosition extends AbstractValueObject {
     /**
      * @param mixed $tax
      */
-    public function setTax($tax): void
+    public function setTax($tax)
     {
         $this->tax = $tax;
     }
@@ -142,7 +142,7 @@ class OrderPosition extends AbstractValueObject {
     /**
      * @param mixed $quantity
      */
-    public function setQuantity($quantity): void
+    public function setQuantity($quantity)
     {
         $this->quantity = $quantity;
     }

--- a/ValueObjects/OrderStatus.php
+++ b/ValueObjects/OrderStatus.php
@@ -27,7 +27,7 @@ class OrderStatus extends AbstractValueObject {
     /**
      * @return float
      */
-    public function getAmount(): float
+    public function getAmount()
     {
         return $this->amount;
     }
@@ -35,7 +35,7 @@ class OrderStatus extends AbstractValueObject {
     /**
      * @param float $amount
      */
-    public function setAmount(float $amount): void
+    public function setAmount(float $amount)
     {
         $this->amount = $amount;
     }
@@ -43,7 +43,7 @@ class OrderStatus extends AbstractValueObject {
     /**
      * @return string
      */
-    public function getAfterbuyOrderId(): string
+    public function getAfterbuyOrderId()
     {
         return $this->afterbuyOrderId;
     }
@@ -51,7 +51,7 @@ class OrderStatus extends AbstractValueObject {
     /**
      * @param string $afterbuyOrderId
      */
-    public function setAfterbuyOrderId(string $afterbuyOrderId): void
+    public function setAfterbuyOrderId(string $afterbuyOrderId)
     {
         $this->afterbuyOrderId = $afterbuyOrderId;
     }
@@ -59,7 +59,7 @@ class OrderStatus extends AbstractValueObject {
     /**
      * @return \DateTime
      */
-    public function getPaymentDate(): \DateTime
+    public function getPaymentDate()
     {
         return $this->paymentDate;
     }
@@ -67,7 +67,7 @@ class OrderStatus extends AbstractValueObject {
     /**
      * @param \DateTime $paymentDate
      */
-    public function setPaymentDate(\DateTime $paymentDate): void
+    public function setPaymentDate(\DateTime $paymentDate)
     {
         $this->paymentDate = $paymentDate;
     }
@@ -75,7 +75,7 @@ class OrderStatus extends AbstractValueObject {
     /**
      * @return \DateTime
      */
-    public function getShippingDate(): \DateTime
+    public function getShippingDate()
     {
         return $this->shippingDate;
     }
@@ -83,7 +83,7 @@ class OrderStatus extends AbstractValueObject {
     /**
      * @param \DateTime $shippingDate
      */
-    public function setShippingDate(\DateTime $shippingDate): void
+    public function setShippingDate(\DateTime $shippingDate)
     {
         $this->shippingDate = $shippingDate;
     }

--- a/ValueObjects/ProductPicture.php
+++ b/ValueObjects/ProductPicture.php
@@ -18,7 +18,7 @@ class ProductPicture
      *
      * @return string
      */
-    public function getNr(): string
+    public function getNr()
     {
         return $this->nr;
     }
@@ -28,7 +28,7 @@ class ProductPicture
      *
      * @param string $nr
      */
-    public function setNr(string $nr): void
+    public function setNr(string $nr)
     {
         $this->nr = $nr;
     }
@@ -36,7 +36,7 @@ class ProductPicture
     /**
      * @return string
      */
-    public function getUrl(): string
+    public function getUrl()
     {
         return $this->url;
     }
@@ -44,7 +44,7 @@ class ProductPicture
     /**
      * @param string $url
      */
-    public function setUrl(string $url): void
+    public function setUrl(string $url)
     {
         $this->url = $url;
     }
@@ -52,7 +52,7 @@ class ProductPicture
     /**
      * @return string
      */
-    public function getAltText(): string
+    public function getAltText()
     {
         return $this->altText;
     }
@@ -60,7 +60,7 @@ class ProductPicture
     /**
      * @param string $altText
      */
-    public function setAltText(?string $altText): void
+    public function setAltText(?string $altText)
     {
         if ($altText === null) {
             $altText = '';


### PR DESCRIPTION
Declaration of return types is a feature introduced with PHP 7.1. In January 2019 the support for PHP 7.0 ended. Shopware is still running their tests with PHP 7.0. That's pretty awesome Shopware. Thumbs up!