### PR TITLE
0066652: Bugfix: transmit Paypal Transaction ID

### DIFF
--- a/Services/Helper/ShopwareOrderHelper.php
+++ b/Services/Helper/ShopwareOrderHelper.php
@@ -1007,6 +1007,7 @@ class ShopwareOrderHelper extends AbstractHelper
             $order->setPaid(true);
             $order->setCleared(true);
         }
+        $order->setPaymentStatus($entity->getPaymentStatus()->getName());
     }
 
     /**

--- a/Services/WriteData/External/WriteOrdersService.php
+++ b/Services/WriteData/External/WriteOrdersService.php
@@ -108,6 +108,7 @@ class WriteOrdersService extends AbstractWriteDataService implements WriteDataIn
                 'SetPay' => $value->isCleared() ? 1 : 0,
                 'CheckVID' => 1,
                 'CheckPackstation' => 1,
+                'PaymentStatus' => $value->getPaymentStatus(),
                 'PaymentTransactionId' => $value->getTransactionId(),
                 'AdditionalInfo' => $value->getTrackingNumber()
             );

--- a/ValueObjects/Order.php
+++ b/ValueObjects/Order.php
@@ -120,6 +120,11 @@ class Order extends AbstractValueObject {
     public $trackingNumber;
 
     /**
+     * @var string
+     */
+    public $paymentStatus;
+
+    /**
      * @return bool
      */
     public function isCleared()
@@ -389,6 +394,22 @@ class Order extends AbstractValueObject {
     public function setTransactionId(string $transactionId)
     {
         $this->transactionId = $transactionId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPaymentStatus()
+    {
+        return $this->paymentStatus;
+    }
+
+    /**
+     * @param string $paymentStatus
+     */
+    public function setPaymentStatus(string $paymentStatus)
+    {
+        $this->paymentStatus = $paymentStatus;
     }
 
     /**


### PR DESCRIPTION
* fixes transmission of Paypal Transaction ID to Afterbuy not working because "Paymentstatus" field is mandatory when transmitting the Transaction ID.