### PR TITLE
AB auction view - direct link to product and show articlenumber - Update WriteOrdersService.php

### DIFF
--- a/Services/WriteData/External/WriteOrdersService.php
+++ b/Services/WriteData/External/WriteOrdersService.php
@@ -125,12 +125,33 @@ class WriteOrdersService extends AbstractWriteDataService implements WriteDataIn
                     $mainNumber = preg_replace('~\D~', '', $position->getInternalIdentifier());
                 }
 
+				/* ************************************************
+				$directShopLink 
+				0 default (old / default behavior up to Aferbuy Connector v.1.0.3)
+				1 for direct link with article number in afterbuy auction overview
+				
+				ToDo:
+				- include variable to plugin config screen or modify sourcecode (fixed) if old method / value is not needed anymore.
+				- find a better (more secure) way to read the shop URL. Maybe from Shopware config and optional with subfolder, if shop is not in the root directory.
+				- optional - not needed but maybe a little bit better - replace the whole article_link with the exact string read and generated from the article directly. - maybe a more optimized way.
+				************************************************ */
+				$directShopLink = 1;
+
+				if ($directShopLink == 1)
+					$mainNumber = $position->getInternalIdentifier();		// Shopware article number
+                
                 if(empty($mainNumber)) {
                     $mainNumber = 0;
                 }
 
                 $orders[$internalIdentifyer]['Artikelnr_' . $i] = $mainNumber;
-                $orders[$internalIdentifyer]['Artikelnr1_' . $i] = $position->getExternalIdentifier();
+				if ($directShopLink == 1) {
+					$orders[$internalIdentifyer]['Artikelnr1_' . $i] = $position->getInternalIdentifier();										// Shopware article number
+					$websiteUrl = 'https://' . $_SERVER['SERVER_NAME'];																			// read Shop URL - better replace with shopURL from Shopware config...
+					$orders[$internalIdentifyer]['ArtikelLink_' . $i] = $websiteUrl . '/search?sSearch=' . $position->getInternalIdentifier();	// direct Link to the shop article
+				} else {
+					$orders[$internalIdentifyer]['Artikelnr1_' . $i] = $position->getExternalIdentifier();										// Shopware EAN (old method / value)
+				}
 
                 $orders[$internalIdentifyer]['ArtikelStammID_' . $i] = $position->getInternalIdentifier();
 

--- a/Services/WriteData/External/WriteOrdersService.php
+++ b/Services/WriteData/External/WriteOrdersService.php
@@ -138,7 +138,8 @@ class WriteOrdersService extends AbstractWriteDataService implements WriteDataIn
 				$directShopLink = 1;
 
 				if ($directShopLink == 1)
-					$mainNumber = $position->getInternalIdentifier();		// Shopware article number
+					// $mainNumber = $position->getInternalIdentifier();				// Shopware article number - removed 2020-12-09 because if not numeric, AB-Response is not successful. Need to be numeric value for afterbuy.
+					$mainNumber = preg_replace('/[^0-9]/', '', $position->getInternalIdentifier());	// Shopware article number (with replaces all which is not numeric)
                 
                 if(empty($mainNumber)) {
                     $mainNumber = 0;


### PR DESCRIPTION
![ab_directlink](https://user-images.githubusercontent.com/75639729/101545279-53039f00-39a7-11eb-905e-de7b5c43f9ee.jpg)
Show article number instead of EAN in aferbuy auction view and add direct link - Update WriteOrdersService.php

Changelog 2020-12-08
modified afterbuy order request
-> shows article number in afterbuy auction overview instead of EAN
-> direct link to the shop product
-> similar behavior as with the TBE-Net plugin before